### PR TITLE
Add instructions for Prometheus in configuring client doc

### DIFF
--- a/content/Products/RHOBS/configuring-clients-for-observatorium.md
+++ b/content/Products/RHOBS/configuring-clients-for-observatorium.md
@@ -3,6 +3,7 @@
 - **Authors:**
   - [`@squat`](https://github.com/squat)
   - [`@spaparaju`](https://github.com/spaparaju)
+  - [`@onprem`](https://github.com/onprem)
 
 ## Overview
 

--- a/content/Products/RHOBS/configuring-clients-for-observatorium.md
+++ b/content/Products/RHOBS/configuring-clients-for-observatorium.md
@@ -24,7 +24,7 @@ In order to remote write metrics from a cluster to Observatorium using the OpenS
 
 #### 1. Configure the Cluster Monitoring Stack
 
-The OpenShift Cluster Monitoring stack provides a ConfigMap that can be used to modify the configuration and behavior of the components. The first step is to modify the “cluster-monitoring-config” ConfigMap in the cluster to include a remote-write configuration for Prometheus as shown below:
+The OpenShift Cluster Monitoring stack provides a ConfigMap that can be used to modify the configuration and behavior of the components. The first step is to modify the “cluster-monitoring-config” ConfigMap in the cluster to include a remote write configuration for Prometheus as shown below:
 
 ```yaml
 apiVersion: v1
@@ -48,7 +48,7 @@ data:
 
 #### 2. Deploy the Observatorium Token-Refresher Proxy
 
-Because Prometheus does not have built-in support for acquiring OAuth2 access tokens for authorization, which are required by Observatorium, the in-cluster Prometheus must remote-write its data through a proxy that is able to fetch access tokens and set them as headers on outbound requests. The Observatorium stack provides such a proxy, which may be deployed to the “openshift-monitoring” namespace and guarded by a NetworkPolicy so that only Prometheus can use the access tokens. The following snippet shows an example of how to deploy the proxy for the stage environment:
+Because Prometheus does not have built-in support for acquiring OAuth2 access tokens for authorization, which are required by Observatorium, the in-cluster Prometheus must remote write its data through a proxy that is able to fetch access tokens and set them as headers on outbound requests. The Observatorium stack provides such a proxy, which may be deployed to the “openshift-monitoring” namespace and guarded by a NetworkPolicy so that only Prometheus can use the access tokens. The following snippet shows an example of how to deploy the proxy for the stage environment:
 
 ```bash
 export TENANT=<your-tenant>
@@ -169,19 +169,19 @@ spec:
 EOF
 ```
 
-### Using a self-managed Prometheus server
+### Using a Self-Managed Prometheus Server
 
 This section describes the process of sending metrics collected by a Prometheus server to Observatorium.
 
 #### Background
 
-In order to remote write metrics from a Prometheus server to Observatorium, the server must be configured to authenticate and make requests to the correct URL using the [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) section of the Prometheus configuration file. Prometheus needs to be configured to use OAuth2 for authenticating the remote write requests to Observatorium. This can be done by setting appropriate fields in [`oauth2`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#oauth2) section under [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
+In order to remote write metrics from a Prometheus server to Observatorium, the server must be configured to authenticate and make requests to the correct URL using the [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) section of the Prometheus configuration file. Prometheus needs to be configured to use OAuth2 for authenticating the remote write requests to Observatorium. This can be done by setting appropriate fields in the [`oauth2`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#oauth2) section under [`remote_write`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write).
 
-> **NOTE:** OAuth2 support to Prometheus was added in the version 2.27.0. If using an older version of Prometheus without native OAuth2 support, the remote write traffic needs to go through token-refresher, similar to what is described above for Cluster Monitoring Stack.
+> **NOTE:** OAuth2 support was added to Prometheus in version 2.27.0. If using an older version of Prometheus without native OAuth2 support, the remote write traffic needs to go through a proxy such as [token-refresher](https://github.com/observatorium/token-refresher/), similar to what is described above for Cluster Monitoring Stack.
 
 #### 1. Modify the Prometheus configuration
 
-The configuration file for Promethehus must be patched to include a remote-write configuration as shown below. `<tenant>`, `<client_id>`, and `<client_secret>` needs to be replaced with appropriate values.
+The configuration file for Prometheus must be patched to include a remote write configuration as shown below. `<tenant>`, `<client_id>`, and `<client_secret>` need to be replaced with appropriate values.
 
 ```yaml
 remote_write:


### PR DESCRIPTION
This PR adds instructions for configuring a self-managed Prometheus for Observatorium.

Preview: https://deploy-preview-18--rhobs-handbook.netlify.app/products/rhobs/configuring-clients-for-observatorium.md/#using-a-self-managed-prometheus-server