### PR TITLE
Remove mention of non-24/7 support

### DIFF
--- a/content/Teams/observability-platform/sre.md
+++ b/content/Teams/observability-platform/sre.md
@@ -90,16 +90,6 @@ Currently, RHOBS services are supported 24h/7d by two teams:
 * `AppSRE` team for infrastructure and "generalist" support. They are our first incident response point. They try to support our stack as far as runbooks and general knowledge allows.
 * `Observability Platform` Team (Dev on-call) for incidents impacting SLA outside of the AppSRE expertise (bug fixes, more complex troubleshooting). We are notified when AppSRE needs.
 
-As of 2021-09-21 on-call rotation schedule changed to accommodate team membership changes. Currently, there is only Bartek on-call every single week per 4 weeks. Then we have "fake" slot named "Antoine", which represents NO on-call duties during that time for dev team. This means any bigger problems outside of office hours handled by AppSRE only and delegated to next office hours (worse case ~3 days). Our SLOs should take this into account.
-
-The change looks as follows (showing two example months):
-
-![RHOBS](../../assets/on-call2021.png)
-
-![RHOBS](../../assets/on-call2021-2.png)
-
-With the time we will be adding more team members to on-call rota to fill gaps.
-
 ## Incident Handling
 
 This is the process we as the Observability Team try to follow during incident response.


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Since we're back to full 24/7 support, remove this outdated section.