### PR TITLE
WIP: Adds handbook-usage content

### DIFF
--- a/content/communication/README.md
+++ b/content/communication/README.md
@@ -1,0 +1,93 @@
+## Writing style guidelines
+
+1. {: #american-english} At GitLab, we use American English as the standard written language.
+2. Do not use rich text, it makes it hard to copy/paste. Use [Markdown](/handbook/markdown-guide/) to format text that is stored in a Git repository. In Google Docs use "Normal text" using the style/heading/formatting dropdown and paste without formatting.
+3. Do not use ALL CAPS because it [feels like shouting](https://en.wikipedia.org/wiki/All_caps#Association_with_shouting). However, there is the [`#all-caps` Slack channel](https://gitlab.slack.com/archives/C01BC085AVB) for your good-natured shouting needs.
+4. We use Unix style (lf) line endings, not Windows style (crlf), please ensure `*.md text eol=lf` is set in the repository's `.gitattributes` and run `git config --global core.autocrlf input` on your client.
+5. Always write a paragraph on a single line. Use soft breaks ("word wrap") for readability. Do not put in a hard return at a certain character limit (e.g., 80 characters) and don't set your IDE to automatically insert hard breaks. Merge requests for the blog and handbook are very difficult to edit when hard breaks are inserted.
+6. Do not create links like "here" or "click here". All links should have relevant anchor text that describes what they link to, such as: "GitLab CI source installation documentation". Using [meaningful links](https://www.futurehosting.com/blog/links-should-have-meaningful-anchor-text-heres-why/){:rel="nofollow noindex"} is important to both search engine crawlers (SEO) and accessibility for people with learning differences and/or physical disabilities. This guidance should be followed in all places links are provided, whether in the handbook, website, GoogleDocs, or any other content. Avoid writing GoogleDocs content which states - `Zoom Link [Link]`. Rather, paste the full link directly following the word `Zoom`. This makes the link more prominent and makes it easier to follow while viewing the document.
+7. When specifying measurements, please include both Metric and Imperial equivalents.
+8. Although we're a San Francisco based company we're also an internationally diverse one. Please do not refer to team members outside the US as international, instead use non-US. Please also avoid the use of offshore/overseas to refer to non-American continents.
+9. If you have multiple points in a comment or email, please number them. Numbered lists are easier to reference during a discussion over bulleted lists.
+10. When you reference an issue, merge request, comment, commit, page, doc, etc. and you have the URL available please paste that in.
+11. In making URLs, always prefer hyphens to underscores, and always use lowercase.
+12. The community includes users, contributors, core team members, customers, people working for GitLab Inc., and friends of GitLab. If you want to refer to "people not working for GitLab Inc." just say that and don't use the word community. If you want to refer to people working for GitLab Inc. you can also use "the GitLab Inc. team" but don't use the "GitLab Inc. employees".
+13. When we refer to the GitLab community excluding GitLab team members please say "wider community" instead of "community".
+14. All people working for GitLab (the company) are the [GitLab team](/company/team/). We also have the [Core team](/community/core-team/) that consists of volunteers.
+15. Please always refer to GitLab Inc. people as GitLab team members, not employees.
+16. Use [inclusive and gender-neutral language](https://techwhirl.com/gender-neutral-technical-writing/) in all writing.
+17. Always write "GitLab" with "G" and "L" capitalized, even when writing "GitLab.com", except within URLs. When "gitlab.com" is part of a URL it should be lowercase.
+18. Refer to products by tier name only on Marketing pages: Our tier names are Ultimate, Premium, and Free. When both deployment models are being referred to (SaaS and self-managed), use the tier name only. When only one of the deployment models is being referred to, prefix the tier name with the deployment model. E.g., SaaS-Premium, Self-Managed-Ultimate.
+19. Correct capitalization of self-managed: The term `self-managed` should not be capitalized unless it's in a title or unless you are writing the full product name ("Self-Managed-Ultimate"). If it is used at the beginning of a sentence, then the first word only is capitalized: "Self-managed".
+20. Refer to environments that are installed and run by the end-user as "self-managed."
+21. Write a [group](/handbook/product/categories/#hierarchy) name as ["Stage:Group"](/handbook/product/categories/#naming) when you want to include the stage name for extra context.
+22. Do not use a hyphen when writing the term "open source" except where doing so eliminates ambiguity or clumsiness.
+23. Monetary amounts shouldn't have one digit, so prefer $19.90 to $19.9.
+24. If an email needs a response, write the answer at the top of it.
+25. Use the future version of words, just like we don't write internet with a capital letter anymore. We write frontend and webhook without a hyphen or space.
+26. Our homepage is https://about.gitlab.com/ (with the `about.` and with `https`).
+27. Try to use the [active voice](https://writing.wisc.edu/Handbook/CCS_activevoice.html) whenever possible.
+28. If you use headers, properly format them (`##` in Markdown, "Heading 2" in Google Docs); start at the second header level because header level 1 is for titles. Do not end headers with a colon. Do not use emoji in headers as these cause links to have strange characters.
+29. Always use a [serial comma](https://en.wikipedia.org/wiki/Serial_comma) (a.k.a. an "Oxford comma") before the coordinating conjunction in a list of three, four, or more items.
+30. Always use a single space between sentences rather than two.
+31. Read our [Documentation Styleguide](https://docs.gitlab.com/ee/development/documentation/styleguide/) for more information when writing documentation.
+32. Do not use acronyms when you can avoid them. Acronyms have the effect of excluding people from the conversation if they are not familiar with a particular term. Example: instead of `MR`, write `merge request (MR)`.
+    1. If acronyms are used, expand them at least once in the conversation or document and define them in the document using [Kramdown abbreviation syntax](https://kramdown.gettalong.org/syntax.html#abbreviations). Alternatively, link to the definition.
+    2. If you don't know the meaning of an acronym, ask. It's always ok to [speak up](/handbook/values/#share).
+33. We segment our customers/prospects into 4 segments [Strategic, Large, Mid-Market, and Small Medium Business (SMB)](/handbook/sales/field-operations/gtm-resources/).
+
+## Simple language
+
+{: #simple-language}
+
+Simple Language is meant to encourage everyone at GitLab to simplify the language we use. We should always use the most clear, straightforward, and meaningful words possible in every conversation. Avoid using "fluff" words, jargon, or "corporate-speak" phrases that don't add value.
+
+When you **don't** use Simple Language, you:
+
+- Confuse people and create a barrier for participants of your conversation.
+- Cause others to not speak up in a meeting because they don't understand what you're saying.
+- Are not inclusive of those whose first language is not English.
+- Do not add value with your words.
+
+When you **do** use Simple Language, you:
+
+- Get work done more efficiently.
+- Build credibility with your audience (your team, coworker, customer, etc.).
+- Keep people's attention while you're speaking.
+- Come across more confident and knowledgeable.
+
+**Here's an example:**
+
+*Original sentence*
+
+> We're now launching an optimization of our approach leveraging key learnings from the project's postmortem.
+
+*A Simple Language sentence*
+
+> We're creating a new plan based on what we learned from this project.
+
+Simple Language is important both when we're speaking to other team members and when we're representing GitLab to people outside the company.
+
+Be sure to use Simple Language in written communications as well. Our handbook, website, docs, marketing materials, and candidate or customer emails should be clear, concise, and effective. Corporate marketing maintains guidelines on [GitLab's tone of voice](https://design.gitlab.com/brand/overview#tone-of-voice).
+
+| Instead of...                       | Try...                                        |
+|-------------------------------------|-----------------------------------------------|
+| Getting buy-in/Getting alignment    | Asking for feedback since DRIs make decisions |
+| Synergy                             | Effective Collaboration                       |
+| Get all your ducks in a row         | Be organized                                  |
+| Do not let the grass grow too long  | Work quickly                                  |
+| Leverage                            | Use more explicit phrasing- debt, etc.        |
+| Send it over the wall               | Share it with a customer                      |
+| Boil the ocean                      | Waste time                                    |
+| Punt                                | Make less of a priority                       |
+| Helicopter view/100 foot view       | A broad view of the business                  |
+| Turtles all the way down            | Cascade through the organization              |
+| When someone has spare/extra cycles | When someone is available                     |
+
+### Inefficient things shouldn't sound positive
+
+For example, do not suggest that you're "working in real-time" when a matter is in disarray. Convey that a lack of organization is hampering a result, and provide feedback and clear steps on resolving.
+
+Do not use a cool term such as "tiger team" when the [existing term of "working group"](/company/team/structure/working-groups/) is more exact. While cool terms such as these may be useful for persuading colleagues to join you in working towards a solution, the right way isn't to use flowery language.
+
+The last example is when we used 'Prioritizing for Global Optimization' for what we now call a [headcount reset](/handbook/product/product-processes/#headcount-resets). When we [renamed it](https://gitlab.com/gitlab-com/www-gitlab-com/-/merge_requests/31101/diffs) we saw a good reduction in the use of this disruptive practice of moving people around.

--- a/content/communication/confidentiality-levels/README.md
+++ b/content/communication/confidentiality-levels/README.md
@@ -1,0 +1,53 @@
+## Public by default
+
+At RedHat, we are [public by default](/handbook/values/#public-by-default), but some information is classified as internal or limited access. This page provides details on confidentiality levels.
+
+## Not public
+
+We make things public by default because [freedom is one of our values](https://www.redhat.com/en/about/brand/standards/culture). Some things can't be made public and are either [internal](#internal) to the company or have [limited access](#limited-access) even within the company. If something isn't listed in the sections below we should make it available externally.
+
+### Internal
+
+Some things are **internal**, available internally but not externally. In instances where a topic should only be accessible to team members, but we would otherwise have a page in the public handbook, it can be added to RedHat's [internal handbook](.). It is okay to refer to the public handbook or the internal and public handbooks in agregate as "the handbook." The internal handbook should always be referred to as the "internal handbook."
+
+The following items are internal:
+
+1. Security and abuse vulnerabilities are not public since they would allow attackers to compromise RedHat products. We do make them public after we remediated a vulnerability. Issues that discuss how to improve upon the security posture of an implementation that is working as intended can be made public, and are often labeled as feature proposals. Security and abuse implementations that detect malicious activities cannot be made public because doing so would undermine our operations.
+2. Financial information, including revenue and costs for the company, is confidential because we are a public company (through IBM) and, as such, need to limit both the timing and content of financial information as investors will use and rely on it as they trade in IBM stock. As the guideline, if it is a first step to constructing a profit, we need to keep it confidential. Examples include:
+   - The specific [IACV](/handbook/sales/sales-term-glossary/arr-in-practice/) of an opportunity
+   - Total monthly cash inflow/outflow for RedHat
+   - Spend of more than 10%
+   - A department's cost
+   - Team member retention (analysts may make business assumptions based on this)
+   - The Sales pipeline (but the Marketing pipeline can be public)
+   - Net and gross retention KPIs. Only the actual numbers can't be public. Everything else--the goal, their calculation, etc.--can be.
+3. All external communications about any financal information should be in line with the company's [SAFE Guidelines](/legal/safe-framework/).
+4. Deals with external parties like contracts and approving and paying invoices.
+5. Content that would compromise a RedHat team member, customer, or user's personal data as defined by [GDPR](https://gdpr.eu/article-4-definitions/), unless explicit consent has been provided by the data owner. Examples of compromising content include a name, an identification number, location data, an online identifier, or one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person.
+6. Legal discussions are not public due to the purpose of Attorney-Client Privilege.
+7. Acquisition offers for us are not public since informing people of an acquisition that might not happen can be very disruptive.
+8. Acquisition offers we give are not public since the organization being acquired frequently prefers to have them stay private.
+9. Customer information is not public since customers are not comfortable with that, and it would make it easier for competitors to approach our customers. If an issue needs to contain *any* specific information about a customer, including but not limited to company name, employee names, number of users, the issue should be made confidential. Try to avoid putting customer information in an issue by describing them instead of naming them and linking to their SalesForce account. When we discuss a customer by name that is not public unless we're sure the customer is OK with that. When we discuss a competitor (for example in a sales call) this can be public as our competitive advantages are public.
+10. Competitive sales and marketing campaign planning is confidential since we want to minimize the time the competition has to respond to it.
+11. Discussions that involve decisions related to country of residence are not public as countries are a core part of people's identity and any communication should have complete context.
+12. If public information compromises the physical safety of one or more team members, it will be made not public because creating a safe, inclusive environment for team members is important to how we work. Information that might compromise the physical safety of a team member includes doxxing or threats made against a team member.
+13. Information related to a press embargo, or related to an upcoming publication where the response will be managed by our external communications team
+14. Information that relies on someone else's copyrighted IP.
+15. Information related to early exploratory initiatives in which premature sharing of information could slow down purchases.
+16. Specific details about our hiring processes such as our scoring rubrics & criteria are not public as we want to ensure candidates provide an accurate overview of their experience and do not falsify their responses to meet our criteria.
+
+### Limited access
+
+The items below are not shared with all team members. Limited access is a more severe restriction than [internal](#internal).
+
+1. Deals with external parties like contracts and approving and paying invoices.
+2. Content that would violate confidentiality for a RedHat team-member, customer, or user.
+3. Customer lists and other customer information are not public since many customers are not comfortable with that and it would make it easier for competitors to approach our customers. If an issue needs to contain *any* specific information about a customer, including but not limited to company name, employee names, and/or number of users, the issue should be made confidential. Avoid putting customer information in an issue by describing them instead of naming them and by linking to their Salesforce account.
+4. Plans for reorganizations. Reorganizations cause disruption and the plans tend to change a lot before being finalized, so being public about them prolongs the disruption. We will keep relevant team members informed whenever possible.
+5. Some discussions on team process and policy changes. Some organizational policies are sensitive in nature and require thoughtful consideration before messaging the changes internally and externally. Relevant team members and leaders will be informed whenever possible.
+6. Legal discussions are restricted to the purpose of Attorney-Client Privilege.
+7. Some information is kept confidential by the Security Team to protect the privacy, safety, and security of team members and applicants, including: job applications, background check reports, reference checks, compensation, terminations details, demographic information (age and date of birth, family or marital status, national identification such as passport details or tax ID, required accommodations), home address. Whistleblower identity is likewise confidential. Performance improvement plans, disciplinary actions, as well as individual feedback are restricted as they may contain negative feedback and negative feedback is 1-1 between you and your manager.
+8. Performance improvement plans, disciplinary actions, as well as individual feedback, are confidential as they contain private negative feedback and negative feedback is 1-1 between team members and managers
+9. Acquisition offers for us are not public since informing people of an acquisition that might not happen can be very disruptive
+10. Acquisition offers we give are not public since the organization being acquired frequently prefers to have them stay private.
+11. Compensation Changes: RedHat will communicate and train team members on the output of iterations to the Total Rewards offerings (Compensation, Equity, Benefits), but team members will not have visibility into the inputs and decision making of compensation changes.

--- a/content/handbook-usage/README.md
+++ b/content/handbook-usage/README.md
@@ -1,0 +1,211 @@
+## Flow Structure
+
+1. A (process) problem comes up, frequently in an issue or chat.
+2. A proposal is made in a merge request to the handbook.
+3. Once merged, the change is announced by linking to the diff in the MR or commit. Major and Medium ones are posted in the #team-monitoring channel for visibility, with a one line summary of the change. If there was an issue, close it out with a link to the diff.
+
+Sometimes you want to have real time editing of a proposal during a meeting and you need to use a Google Doc for that. When doing so the first item should be the URL of the handbook page this content will be moved to when the meeting is over.
+
+## Why handbook first
+
+Documenting in the handbook before taking an action may require more time initially because you have to think about where to make the change, integrate it with the existing content, and then possibly add to or refactor the handbook to have a proper foundation. But, it saves time in the long run, and this communication is essential to our ability to continue scaling and adapting our organization.
+
+This process is not unlike writing tests for your software. Only communicate a (proposed) change via a change to the handbook; don't use a presentation, email, chat message, or another medium to communicate the components of the change. These other forms of communication might be more convenient for the presenter, but they make it harder for the audience to understand the context and the implications for other potentially affected processes.
+
+Having a **"handbook first"** mentality ensures there is no duplication; the handbook is always up to date, and others are better able to contribute.
+
+Beyond being "handbook first," we are also "public handbook first." When information is [internal-only](communication/confidentiality-levels/#internal), it should be captured in the internal handbook, but we default to the public handbook for anything that can be [made public](communication/confidentiality-levels/#not-public). This ensures that everyone has access to any information that can be [SAFEly](legal/safe-framework/) shared. This supports the [RedHat values](https://www.redhat.com/en/about/brand/standards/culture), including freedom, accountability, and commitment. It also protects against the internal handbook becoming a home for information that should otherwise be public or a conflicting or duplicative source of truth.
+
+When asked during an [INSEAD](http://insead.edu/) case study interview about challenges related to being all-remote, GitLab co-founder and CEO Sid Sijbrandij provided the following reply.
+
+> The biggest problem is GitLab not working handbook first. We have an amazing handbook that allows us to collaborate, onboard new people, and think collectively.
+>
+> However, it is counterintuitive to communicate changes to the handbook. The default of people, when they wish to communicate a change, is to send a Slack message, send an email, give a presentation, or tell people in a meeting — *anything* but make a change in the handbook.
+>
+> It's slower for them. It's quicker to use any other form. If they make a change in the handbook, they first have to find the relevant part of the handbook, they sometimes have to adjust the handbook to make sure their change will fit in, they have to go through a technical process and a review or two, and they have to wait a bit before it's deployed.
+>
+> It's slower than any other option. However, it allows people that commit a change after that to build upon a change. When they take that extra time, it's building a foundation for the next thing.
+>
+> I think of it as brick laying. Every piece of information is a brick. At GitLab, there is a well-structured house, and everyone adds to that one house. Because we're pretty particular on how we build it, it has a strong foundation and we can build it very high.
+>
+> In every other company, they send the brick into the hands of people. Everyone is receiving bricks daily that they have to add to the house they're building internally. They forget things and things are unclear. A lot of context has to be created because there is no context around where to place the bricks.
+>
+> So, you can end up with a thousand houses that look quite different, that are all hanging a bit, and each time you add a brick to the top one pops out at the bottom. — *GitLab co-founder and CEO Sid Sijbrandij*
+
+## Handbook guidelines
+
+Please follow these guidelines and remind others of them.
+
+### How we use the guide every day
+
+1. Most guidelines in this handbook are meant to help, and unless otherwise stated, are meant to help more than being absolute rules. Don't be afraid to do something because you don't know the entire handbook, nobody does. Be gentle when reminding people about these guidelines. For example say, "It is not a problem, but next time please consider the following guideline from the handbook."
+2. If you ask a question and someone answers with a link to the handbook, they do this because they want to help by providing more information. They may also be proud that we have the answer documented. It doesn't mean that you should have read the entire handbook, nobody knows the entire handbook.
+3. If you need to ask a team member for help, please realize that there is a good chance the majority of the community also doesn't know the answer. Be sure to **document** the answer to radiate this information to the whole community. After the question is answered, discuss where it should be documented and who will do it. You can remind other people of this request by asking "Who will document this?"
+4. When you discuss something in chat always try to **link** to a URL where relevant. For example, the documentation you have a question about or the page that answered your question. You can remind other people of this by asking "Can you please link?"
+5. Remember, the handbook is not what we hope to do, what we should formally do, or what we did months ago. **It is what we do right now.** Make sure you change the handbook in order to truly change a process. To propose a change to a process, make a merge request to change the handbook. Don't use another channel to propose a handbook change (email, Google Doc, etc.).
+6. The handbook is the process. Any sections with names like 'process', 'policies', 'best practices', or 'standard operating procedures' are an indication of a deeper problem. This may indicate a duplication between a prose description of a process and a numbered list description of the same process that should be combined in one description of the process.
+7. When communicating something always include a link to the relevant (and up-to-date) part of the **handbook** instead of including the text in the email/chat/etc. You can remind other people of this by asking "Can you please link to the relevant part of the handbook?"
+8. Everyone should subscribe to the `#handbook` channel to stay up-to-date with changes to the handbook
+
+### How to change or define a process
+
+1. To change a guideline or process, **suggest an edit** in the form of a merge request.
+2. When working to get your change merged quickly, make sure you are asking the appropriate team members with merge rights. Not sure who is responsible? Consult (and add to) the `CODEOWNERS` [repository](https://github.com/rhobs/handbook/-/blob/master/.github/CODEOWNERS).
+3. After it is merged you can post this in the `#team-monitoring` slack channel if applicable. You can remind other people of this by asking "Can you please send a merge request for the handbook?"
+4. When substantially changing handbook layout, please leave a link to the specific page of the review app **that is directly affected by this MR**. Along with the link, include as much info as possible in the MR description. This will allow everyone to understand what is the purpose of the MR without looking at diffs.
+5. Keeping up with changes to the Handbook can be difficult, please follow the [commit subject guidelines](https://docs.gitlab.com/ee/development/contributing/merge_request_workflow.html#commit-messages-guidelines) with a particular focus on your merge request's title.
+6. Communicate process changes by linking to the **merged diff** (a commit that shows the changes before and after). If you are communicating a change for the purpose of discussion and feedback, it is ok to link to an **unmerged diff**. Do not change the process first, and then view the documentation as a lower priority task. Planning to do the documentation later inevitably leads to duplicate work communicating the change and it leads to outdated documentation. You can remind other people of this by asking "Can you please update the handbook first?"
+7. When feasible, introduce process changes iteratively. It is important that you contribute to the handbook by making small merge requests. This will help gain adoption among the process's intended audience. We want to avoid significant process changes that are unnecessarily large, top-down, and disruptive. These types of process changes can disempower directly responsible individual and cause people to focus on process rather than results.
+8. Like everything else, our processes are always in flux. Everything is always in draft, and the initial version should be in the handbook, too. If you are proposing a change to the handbook, whenever possible, **skip the issue and submit a merge request**. (Proposing a change via a merge request is preferred over an issue description). Mention the people that are affected by the change in the merge request. In many cases, merge requests are easier to collaborate on since you can see the proposed changes.
+9. **If something is a limited test** to a group of users, add it to the handbook and note as such. Then remove the note once the test is over and every case should use the new process.
+10. If someone inside or outside RedHat makes a good suggestion invite them to add it to the handbook. Send the person the URL of the relevant page and section and offer to do it for them if they can't. Having them make and send the suggestion will make the change and will reflect their knowledge.
+11. When you submit a merge request, make sure that it gets merged quickly. Making single, small changes quickly will ensure your branch doesn't fall far behind master, creating merge conflicts. Aim to make and merge your update on the same day. Mention people in the merge request or reach them via Slack. If you get a suggestion for a large improvement on top of the existing one consider doing that separately. Create an issue, get the existing MR merged, then create a new merge request.
+12. If you have to move content have a merge request that moves it and does nothing else. If you want to clean it up, summarize it, or expand on it do that after the moving MR is merged. This is much easier to review.
+13. Try to **add the why of a handbook process**, what is the business goal, what is the inspiration for this section. Adding the why makes processes easier to change in the future since you can evaluate if the why changed.
+
+### Style guide and information architecture
+
+#### Single Source of Truth
+
+Think about the information architecture to eliminate repetition and have a Single Source of Truth (SSoT). Instead of repeating content cross-link it (each text has a hyperlink to the other piece). If you copy content please remove it at the origin place and replace it with a link to the new content. Duplicate content leads to more work by having to update the content in multiple places as well as the need to remember where all of the out of date content lives. When you have a single source of truth it's only stored in a single system. Make sure to always cross-link items if there are related items (elsewhere in the handbook, in docs, or in issues).
+
+#### System of Record
+
+A system of record (SoR) is the authoritative data source for a given data element or piece of information. It's worth noting that while it is possible to have a system of record that is also a single source of truth, simply just being a system of record doesn't directly imply it is the single source of truth.
+
+#### Organized by Function and Results
+
+The handbook is **organized by function and result** to ensure every item in it has a location and owner to keep it up to date.
+
+- It's essential that we adhere to this hierarchy and that we not maintain separate structures for company training materials (e.g. onboarding materials, how-tos, etc.), videos, or other documentation.
+- Adhering to this hierarchy is sometimes counter-intuitive. We've learned over the years that keeping content in context helps to ensure consistency when making future updates.
+- At times, a change of perspective may be desired. In those cases, link to relevant sections of the handbook but don't include the content itself.
+
+#### Avoid unstructured content
+
+- **Avoid unstructured content based on formats like Learning Playbooks, [FAQs](https://idratherbewriting.com/2017/06/23/why-tech-writers-hate-faqs/), lists of links (such as quick links), resource pages, glossaries, courses, videos, tests, processes, standard operating procedure, training, or how-to's.** These are very hard to keep up-to-date and are not compatible with organization per function and result. For example: Call it Contract Negotiation Handbook instead of Contract Negotiation Playbook
+- Instead, put the answer, link, definition, course, video, or test in the most relevant place. Use descriptive headings so that people can easily search for content.
+- That said, please mix *formats* where and when appropriate in the handbook, even within a single page. Utilizing multiple formats can be valuable, and different people may prefer certain formats over others.
+- Worry only about the organization **per function and result**, not about how the page will look if you embed varying types and formats of content.
+
+#### Use headings liberally
+
+Headings should have normal capitalization: don't use [ALL CAPS](https://en.wikipedia.org/wiki/All_caps) or [TitleCase](http://www.grammar-monster.com/glossary/title_case.htm). After a heading, leave one blank line; this is [not required in the standard](http://spec.commonmark.org/0.27/#example-46), but it is our convention.
+
+### Editing the handbook
+
+Please read through the [Writing Style Guidelines](/handbook/communication/#writing-style-guidelines) before contributing.
+
+#### Fine points
+
+- Keep your handbook pages short and succinct. Eliminate fluff and get right to the point with the shortest possible wording. Keep in mind that the biggest challenge cited by new employees is the vast amount of information to take in during on-boarding.
+- We don't need [.gitkeep files](https://stackoverflow.com/questions/7229885/what-are-the-differences-between-gitignore-and-gitkeep) in our handbook, they make it harder to quickly open a file in editors. Don't add them, and delete them when you see them.
+
+### Scope of this handbook
+
+- All documentation that also applies to code contributions from the wider community should be in the it's respective projects, not the Handbook, which is only for team members. Read more in the [Documentation](../documentation/) section of the Handbook.
+- The handbook is for things concerning current and future RedHat team-monitoring members only. If something concerns users of RedHat products, it should be documented in the official documentation of the product or in the opensource project.
+
+### Handbook First Competency
+
+In an all-remote, asynchronous organization, each team member should practice handbook first. For more information on what it means to be handbook first, please refer to the [why handbook first](/handbook-usage/#why-handbook-first) section of this page.
+
+**Skills and behaviors of handbook first as a Team Member**:
+
+- Actively contributes to the handbook.
+- [Start with a merge request](/handbook/communication/#start-with-a-merge-request)
+- Provides links information from the handbook when answering questions and if the information doesn't exist in the handbook, then the team member adds it.
+- Understands which information is internal-only, but puts all public information in the public handbook.
+
+**Skills and behaviors of handbook first as a People Leader**:
+
+- Holds their team and others accountable for being handbook first.
+- Demonstrates leadership in being public handbook first with all information that is not internal-only.
+- Enables new team members and managers on how to leverage the handbook as a resource.
+- Serves as a role model for what it means to be handbook first.
+
+### The Internal handbook
+
+TODO (JoaoBraveCoding) As an attempt to try and make the first iteration of the handbook as brief as possible we will introduce the internal handbook on a latter date.
+
+## Management
+
+It is each department and team member's responsibility to ensure the handbooks (public handbook, internal handbook, and staging handbook) stay current. The content in the handbook should be accurate and follow the same format as outlined in the [Guidelines](#handbook-guidelines). For questions on who to submit a merge request to, or assistance with the handbook, please reach out on the `#team-monitoring` Slack channel.
+
+## Screenshot the handbook instead of creating a presentation
+
+Presentations are great for ephemeral content like group conversations and board presentations. [Evergreen content](https://www.michaelbellone.co.uk/blog/the-do-and-donts-of-evergreen-content/) like a leadership training should be based on the handbook. This is an important element of working handbook-first.
+
+In the creation of presentations for evergreen content, please screenshot the handbook and provide links to displayed pages rather than copy and pasting content (or formatting a slide specifically to mirror handbook information). This approach shows a bias towards asynchronous communication, and rationale for this is below.
+
+1. It saves you the effort of needing to both update the handbook and create content for a presentation; the handbook is checked and improved as part of the preparation instead of extra work
+2. The handbook will stay up to date so people don't look at an outdated information in a presentation
+3. Seeing screenshots will confirm to people the content is in the handbook and it is up to date there
+4. People get used to the structure of the handbook and can more easily find the relevant handbook section later on
+5. The content is open for everyone to contribute to when it is in the handbook
+6. The content is integrated with the rest of our processes and shown in context
+7. Many more people will consume the content on a webpage than a presentation because it is easier to search and link
+8. You're helping other organizations and students around the work by giving them an example how we do it
+
+The presentation will look less polished, but the advantages outweigh that concern.
+
+If a synchronous presentation is required, default to sharing your screen and viewing live handbook pages over a slide presentation.
+
+## Make it worthwhile
+
+Companies asked how GitLab managed to work with the handbook because at their company it wasn't working: "There are many occasions where something is documented in the knowledge base, but people don't know about it because they never bothered to read or search. Some people have a strong aversion against what they perceive as a 'wall of text'."
+
+There is an attempt to cover this in GitLab's [guide to embracing a handbook-first approach to documentation](https://about.gitlab.com/company/culture/all-remote/handbook-first-documentation/).
+
+To ensure that people's time is well spent looking at the handbook we should follow the 'handbook guidelines' above, and also:
+
+1. Follow the [writing style guide](/communication/#writing-style-guidelines)
+2. Make it public so you can Google search
+3. Test people on their knowledge during onboarding
+4. Give real examples
+5. Avoid corporate speak, describe things like you're talking to a friend. For more, see our communications guide on [Simple Language](/communication/#simple-language).
+
+## Wiki handbooks don't scale
+
+Company handbooks [frequently start as wikis](/company/culture/all-remote/handbook-first-documentation/#tools-for-building-a-handbook). This format is more comfortable for people to work in than a static website with GitHub Merge Requests and GitHub Pages. However wikis tend to go stale over time, where they are badly organized and get out of date.
+
+In wikis it is impossible to make proposals that touch multiple parts of a page and/or multiple pages. Therefore it is hard to reorganize the handbook. Because GitHub Merge Requests and GitHub Pages are based on distributed version control you can split the role of submitter and approver. This allows for a division of work that keeps the handbook up to date:
+
+- Anyone who can read the handbook can make a proposal
+- Leaders (who tend to be short on time) only have to approve such a proposal
+
+Wikis also do not encourage collaboration on changes, because there is no way to discuss a proposed change like there is with merge requests.
+
+Some wikis make it hard to view and/or link to diffs of changes, which is needed to communicate decisions.
+
+## External use of the Handbook
+
+Our handbook is heavily inspired in GitLab's handbook, to this end please consider they stance on external use.
+
+> Remember that, like virtually everything we do, our handbook is [open source](/solutions/open-source/), and we expect that other companies may use it as inspiration for their own documentation and practices. That said, the handbook should always be specific on **what we do**, not **who we want to be**, and every company will need to fill out their own handbooks over time. Our handbook falls under the [Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/).
+
+## Searching the Handbook
+
+Every RedHat Handbook page has a search field near the top of the page for searching.
+
+## Having Trouble Contributing to the Handbook?
+
+If you run into trouble editing the RedHat Handbook there are various means of help available.
+
+Team members, are available to help you create a merge request or debug any problems you might run into while updating the RedHat Handbook.
+
+### Merge with confidence
+
+Even if you are not a developer, you should feel confident merging any changes that pass the pipeline without worrying that you will break the handbook. The tests in the pipeline are designed to catch any major problems. The `handbook` project is configured so that changes cannot be merged unless the pipeline passes. When in doubt, feel free to loop in a technical reviewer. You can ask for help in the `#team-monitoring` slack channel. Senior team members can provide a technical review or help you fix a broken pipeline. In the event that code is merged that does break the handbook in some way, let the team know as soon as possible.
+
+### When to get approval
+
+Getting pinged to approve every small change to your page can be annoying, but someone changing a policy or procedure in the handbook without proper approval can have strong negative consequences. Use your best judgement on when to ask for approvals.
+
+Whenever reasonable, practice [responsibility over rigidity](/handbook/values/#freedom-and-responsibility-over-rigidity). When you expect a page owner will appreciate your changes, go ahead and merge them without approval. Always ping the code owners with an @mention comment to inform them of the changes. They will be happy their page was made better and they didn’t need to waste time reviewing and approving the change. In the event that something isn’t an improvement, we practice [clean up over sign off](/handbook/values/#cleanup-over-sign-off).
+
+Whenever appropriate, get approval from the [code owner](https://github.com/rhobs/handbook/-/blob/master/.github/CODEOWNERS) before merging changes. The page’s code owner is the DRI for the page and has the final say for what appears in the handbook. When in doubt, get the DRI’s permission before changing their page. Don't worry if the DRI is a senior level person. You can still assign your MRs to them, even if you are an individual contributor. This is because we prefer to communicate directly.
+
+### Have a peer review your changes
+
+Unless it’s a small change like a typo, always have another team member review your changes before you merge them.

--- a/content/legal/safe-framework/README.md
+++ b/content/legal/safe-framework/README.md
@@ -1,0 +1,65 @@
+# **SAFE**
+
+### **Why SAFE?**
+
+RedHat has accomplished a number of milestones and [Freedom](https://www.redhat.com/en/about/brand/standards/culture) has been essential to our success from the beginning. As RedHat matures, and we evolve to viewing Transparency as both Internal Transparency and External Transparency, we want to equip Team Members with the tools to enable responsible transparency in order to protect RedcHat and our Team Members. To do so, there are certain factors we need to consider when we share information in the form of videos, blog posts, social media posts, interviews, presentations, epics, issues, merge requests or any other format.
+
+### **WHAT IS SAFE?**
+
+#### **Sensitive**:
+
+The **S** in “**S**AFE” serves as a reminder to make sure that Team Members are not sharing information which could be considered **S**ensitive information without express approval from RedHat Legal. Things to consider before disclosing:
+1. What is considered **S**ensitive information?
+
+   a) Any company confidential information that is [not public](communication/confidentiality-levels/#not-public).
+
+   b) Any data that reveals information not [generally known or not available](communication/confidentiality-levels/#internal) [externally](communication/confidentiality-levels/#internal) may be considered sensitive information. Sensitive information includes:
+
+   * Team Member data (individual performance, start dates, departures)
+   * Customer or partner information (logos, trademarks, spend)
+
+   c) Material nonpublic information. Material nonpublic information is any information that is not publicly available and a reasonable investor would likely consider important in making an investment decision (i.e., to buy, sell, or hold the company’s stock). Examples of material nonpublic information may include:
+
+   * The company’s intentions to access the capital markets (i.e. selling primary shares, secondary stock activity, issuance of debt);
+   * The company’s financial results;
+   * A possible major new customer win or loss;
+   * A pending exit of one or more senior executives of the company or members of the company’s board;
+   * The security and stability of the company’s platform;
+   * A significant transaction;
+   * A pending purchase or sale of a significant asset or business; and
+   * A pending significant legal or regulatory proceeding or settlement.
+
+The disclosure of sensitive or material nonpublic information may be harmful to Team Members or the company. Team Members should seek the RedHat Legal’s review if the content of what they intend to disclose includes this type of information via the legal@redhat.com.
+
+#### **Accurate**:
+
+The **A** in S**A**FE serves as a reminder to double-check that the information Team Members are sharing is **A**ccurate. Things to consider before disclosing:
+
+1. Is the information being disclosed verifiable? Is there a reference that can be cited? Is there data to backup the information? How would we be able to prove it is accurate if required by an external party?
+2. Are you [DRI](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/) for the accuracy of the material? If you are not able to cite a reference or you are not the [DRI](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/) for this information, did you receive approval from the [DRI](https://about.gitlab.com/handbook/people-group/directly-responsible-individuals/) to share this data?
+
+Team Members have a responsibility to make sure that the information they are sharing is **A**ccurate. Team Members and third parties rely on the information presented and may incorporate the same information in works they may produce. Not only should Team Members make sure that the information is **A**ccurate, but they should be able to provide the underlying data, if applicable, to support the accuracy or confirm the methodology used to achieve the data. Estimates should clearly be marked as estimates. Also, if the data is continually changing, Team Members should indicate an “as of” date when sharing so that everyone is aware of the date the shared data is accurate as of.
+
+#### **Financial**:
+
+The **F** in SA**F**E serves as a reminder that the company’s **F**inancial information is so important to protect that it requires CFO’s approval prior to sharing externally. Things to consider before disclosing:
+
+1. Is there a **F**inancial element such as dollars, performance metrics, or margins including actual results or future expectations contained in the information you are about to share?
+2. Does the information you are about to share include any forward-looking statements? This includes quantitative (something that CAN be expressed as a number) and qualitative (something that CANNOT be expressed as a number) statements.
+3. Is the information related to process and procedures rather than financials and data? Information related to process and procedures is safer to distribute.
+- For example, it would be ok to share the timeline related to when quarterly financials need to be complete but it would not be ok to share the quarterly financial results.
+
+Company financials, including guidance (the company's own best estimates to shareholders of its upcoming earnings), forecasts and estimates are and should be considered confidential nonpublic confidential information. Team Members should also consider that information containing metrics or data can be used to figure a financial value of the company, and should therefore be considered confidential information. Examples of metrics or data that can be used to figure financial value include the number of customers in each offering tier, the contract amount of a large customer, the current 409a valuation for the company’s stock. Accordingly, financial information should not be disclosed publicly unless approved by RedHat’s Chief Financial Officer.
+
+#### **Effect**:
+
+The **E** in SAF**E** serves as a reminder to be mindful about the **E**ffect - intentional and unintentional - that the information Team Members are sharing may have on the company. Things to consider before disclosing:
+
+1. Is the information being disclosed helpful/harmful to the Company, and/or team members?
+2. What **E**ffect could the information have on the “total mix” of information that is being made available?
+
+When considering what information to disclose, Team Members should consider the pros and cons of the **E**ffect the information will have on all parties inside and outside the company. Furthermore, Team Members should also consider that in some instances information intended to have one **E**ffect may have a completely different, unintended **E**ffect. When in doubt, talking it over with a colleague or reaching out via #safe is always a good option.
+
+Team Members should also take into account each piece of information being shared as well as the information and documentation as a whole. The information you are sharing should not be viewed in a silo. Team Members should examine what type of effect all the information taken together will have.
+
+Any questions should be directed to Director of Legal, Corporate via the email legal@redhat.com.


### PR DESCRIPTION
This commit adds the handbook-usage document that aims at establishing a foundation for new and existing team members on what should go on in the handbook and what should not. The content is mostely a corbon copy of GitLab's handbook usage document since it provides a good baseline for the team to build its own handbook.