### PR TITLE
fix: missing tlsConfig for ServiceMonitor example

### DIFF
--- a/content/Products/OpenshiftMonitoring/collecting_metrics.md
+++ b/content/Products/OpenshiftMonitoring/collecting_metrics.md
@@ -189,6 +189,7 @@ spec:
     # Matches the name of the service's port.
     port: metrics
     scheme: https
+    tlsConfig:
       # The CA file used by Prometheus to verify the server's certificate.
       # It's the cluster's CA bundle from the service CA operator.
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt


### PR DESCRIPTION
ServiceMonitor example is missing tlsConfig that caFile, certFile etc should go under ([spec](https://docs.openshift.com/container-platform/4.16/rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.html#spec-endpoints-tlsconfig))