### PR TITLE
chore: change order of OpenShift cluster monitoring pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .envrc
 web/node_modules
 web/resources/_gen
+web/public
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/.mdox.yaml
+++ b/.mdox.yaml
@@ -38,6 +38,31 @@ transformations:
             weight: 2
             pre: <i class='fas fa-users'></i>
 
+  - glob: "Products/OpenshiftMonitoring/collecting_metrics.md"
+    frontMatter:
+      template: |
+        title: "{{ .Origin.FirstHeader }}"
+        lastmod: "{{ .Origin.LastMod }}"
+        weight: 10
+  - glob: "Products/OpenshiftMonitoring/alerting.md"
+    frontMatter:
+      template: |
+        title: "{{ .Origin.FirstHeader }}"
+        lastmod: "{{ .Origin.LastMod }}"
+        weight: 20
+  - glob: "Products/OpenshiftMonitoring/telemetry.md"
+    frontMatter:
+      template: |
+        title: "{{ .Origin.FirstHeader }}"
+        lastmod: "{{ .Origin.LastMod }}"
+        weight: 30
+  - glob: "Products/OpenshiftMonitoring/faq.md"
+    frontMatter:
+      template: |
+        title: "{{ .Origin.FirstHeader }}"
+        lastmod: "{{ .Origin.LastMod }}"
+        weight: 40
+
   - glob: "**/README.md"
     path: _index.md
     frontMatter: &defaultFrontMatter

--- a/content/Products/OpenshiftMonitoring/alerting.md
+++ b/content/Products/OpenshiftMonitoring/alerting.md
@@ -1,3 +1,7 @@
+---
+weight: 20
+---
+
 # Alerting guidelines
 
 Please refer to the [Alerting Consistency](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md) OpenShift enhancement proposal for the recommendations applying to OCP built-in alerting rules.

--- a/content/Products/OpenshiftMonitoring/collecting_metrics.md
+++ b/content/Products/OpenshiftMonitoring/collecting_metrics.md
@@ -1,3 +1,7 @@
+---
+weight: 10
+---
+
 # Collecting metrics with Prometheus
 
 This document explains how to ingest metrics into the OpenShift Platform monitoring stack. **It only applies for the OCP core components and Red Hat certified operators.**

--- a/content/Products/OpenshiftMonitoring/faq.md
+++ b/content/Products/OpenshiftMonitoring/faq.md
@@ -1,3 +1,7 @@
+---
+weight: 40
+---
+
 # Frequently asked questions
 
 This serves as a collection of resources that relate to FAQ around configuring/debugging the in-cluster monitoring stack. Particularly it applies to two OpenShift Projects:

--- a/content/Products/OpenshiftMonitoring/telemetry.md
+++ b/content/Products/OpenshiftMonitoring/telemetry.md
@@ -1,3 +1,7 @@
+---
+weight: 30
+---
+
 # Sending metrics via Telemetry
 
 ## Targeted audience


### PR DESCRIPTION
It changes the order of the CMO pages to show a more natural progression.

From

![image](https://github.com/user-attachments/assets/ef5c4b25-1598-4b54-abd2-bd87fe74c0cf)


To

![image](https://github.com/user-attachments/assets/4238702a-7fb7-4516-bf02-5e67fe83151d)
