### PR TITLE
chore(collecting_metrics.md): recommend the use of serviceDiscoveryRole: EndpointSlice in ServiceMonitor

### DIFF
--- a/content/Products/OpenshiftMonitoring/collecting_metrics.md
+++ b/content/Products/OpenshiftMonitoring/collecting_metrics.md
@@ -171,8 +171,15 @@ rules:
   resources:
   - services
   - endpoints
-  - endpointslices
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list
@@ -248,6 +255,7 @@ spec:
     # Select all Services in the same namespace that have the `app.kubernetes.io/name: my-app` label.
     matchLabels:
       app.kubernetes.io/name: my-app
+  serviceDiscoveryRole: EndpointSlice
 ```
 
 ## Next steps


### PR DESCRIPTION


- [x] wait until I run the downstream check cluster wide that endpoints and endpointsslice generate the same state (same targets/metrics etc): https://issues.redhat.com/browse/MON-4474


- [ ] probably serviceDiscoveryRole is only supported in latest OCP versions???